### PR TITLE
Minor Markdown fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Mission Statement: This build is intented to finish the work of the Project M te
 What This Build is NOT: This build is not meant to be the "tournament standard". It is simply a group of modders coming together with the common goal of finishing Project M the way it was intended to be. This build is not a place to add tons of new characters, nor rebalance the entire game. Perhaps in the future Isaac can be completed, but as of right now, it's much more important to focus on what finishing up on what is almost done than focusing on anything new!
 
 Installation: 
-1) Copy and paste the "projectm" folder in this download onto the root of your SD card 
-2) Copy and paste the "codes" folder to wherever your codes folder is
-3) Copy "gameconfig.txt" to the root of your SD card
-4) Say "Yes" to any overwrites 
+1. Copy and paste the "projectm" folder in this download onto the root of your SD card 
+2. Copy and paste the "codes" folder to wherever your codes folder is
+3. Copy "gameconfig.txt" to the root of your SD card
+4. Say "Yes" to any overwrites 
 
 You're done!
 

--- a/README.md
+++ b/README.md
@@ -18,5 +18,5 @@ Installation:
 You're done!
 
 Thank Yous:
-The old PMDT team, for all their hard work
-Kitsu, for the Lyn Down Special fix
+* The old PMDT team, for all their hard work
+* Kitsu, for the Lyn Down Special fix


### PR DESCRIPTION
Paragraphs need to be separated by one or more blank lines, otherwise they're parsed as a single paragraph. Regardless, bullets are probably more appropriate here.
