### PR TITLE
Reverted gitignore changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,1 @@
 .DS_Store
-projectm/pf/fighter/lyn/FitLyn.pac
-projectm/pf/menu2/sc_selmap.pac
-projectm/pf/fighter/lyn/FitLyn.pac
-projectm/pf/fighter/lyn/FitLyn.pac


### PR DESCRIPTION
There was a mistake in a commit made before which updated the .gitignore, preventing us from versionning Lyn.
This commit fixes this.
